### PR TITLE
 Append key prefix to key if configured to prevent key collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [Unreleased]
+- Added config `keyPrefix` option to prevent key collisions.
+
 ## [1.3.7] - 2018-07-10
 ### Added
 - Varnish: `headers` config option 

--- a/src/EventRegistrar.php
+++ b/src/EventRegistrar.php
@@ -219,6 +219,8 @@ class EventRegistrar
             $tag = Plugin::TAG_PREFIX_STRUCTURE . $event->structureId;
         }
 
+        $tag = Plugin::getInstance()->prepareTag($tag);
+
         // Push to queue
         \Craft::$app->getQueue()->push(new PurgeCacheJob([
                 'tag' => $tag

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -72,7 +72,6 @@ class Plugin extends BasePlugin
         \Craft::$app->getResponse()->attachBehavior('tag-header', TagHeaderBehavior::class);
 
     }
-    
 
     // ServiceLocators
     // =========================================================================
@@ -92,6 +91,17 @@ class Plugin extends BasePlugin
     public function getTagCollection(): TagCollection
     {
         return $this->get('tagCollection');
+    }
+
+    /**
+     * Prepends tag with configured prefix.
+     * To prevent key collision if you use the same
+     * cache server for several Craft installations.
+     *
+     * @return string
+     */
+    public function prepareTag($tag) {
+        return $this->getSettings()->keyPrefix.$tag;
     }
 
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -101,7 +101,7 @@ class Plugin extends BasePlugin
      * @return string
      */
     public function prepareTag($tag) {
-        return $this->getSettings()->keyPrefix.$tag;
+        return $this->getSettings()->getKeyPrefix().$tag;
     }
 
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -93,6 +93,9 @@ class Plugin extends BasePlugin
         return $this->get('tagCollection');
     }
 
+    // Public Methods
+    // =========================================================================
+
     /**
      * Prepends tag with configured prefix.
      * To prevent key collision if you use the same

--- a/src/TagCollection.php
+++ b/src/TagCollection.php
@@ -11,7 +11,7 @@ class TagCollection
 
     public function add(string $tag)
     {
-        $this->tags[] = $tag;
+        $this->tags[] = Plugin::getInstance()->prepareTag($tag);
     }
 
     public function getAll()

--- a/src/config.example.php
+++ b/src/config.example.php
@@ -16,6 +16,12 @@ return [
     // In case the cache driver does not support tag purging
     'useLocalTags'  => true,
 
+    // Optional key prefix, to prevent collisions in case you're using the
+    // same cache store for several Craft installations.
+    // Keep it nice and short for the sake of readability when debugging.
+    // And don't use spaces ...
+    'keyPrefix' => '',
+
     // Drivers settings
     'drivers'       => [
 

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -49,6 +49,13 @@ class Settings extends Model
      */
     public $useLocalTags = true;
 
+    /**
+     * Key prefix
+     *
+     * @var string
+     */
+    public $keyPrefix = '';
+
     // Public Methods
     // =========================================================================
 
@@ -84,6 +91,18 @@ class Settings extends Model
     public function getHeaderTagDelimiter()
     {
         return $this->drivers[$this->driver]['tagHeaderDelimiter'] ?? ' ';
+    }
+
+    /**
+     * Get key prefix.
+     * To prevent key collision if you use the same
+     * cache server for several Craft installations.
+     *
+     * @return string
+     */
+    public function getKeyPrefix()
+    {
+        return $this->keyPrefix;
     }
 
     /**


### PR DESCRIPTION
Pull request for #18 

I did not add a typehint for string on prepareTag() or getKeyPrefix() as I don't know what PHP-version you're targetting. But I guess the plugin is pretty modern....

I've tested that entities, sections and globals gets prefixed tags, and that the purge job does work.
But, I've only tested with the Varnish driver.

Please do tell if I've done obviously stupid things or forgotten something :)