### PR TITLE
adds support for varnish_ban_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ Varnish URL supports multiple servers, separate with comma. E.g `http://1.1.1.1,
 ```
 UPPER_DRIVER=varnish
 VARNISH_URL=<REPLACE-ME>
+VARNISH_BAN_KEY=<UID>
 ```
+`VARNISH_BAN_KEY` lets you specify a unique id which you can pick up in your VCL and issue the correct bans. Very useful when you have multiple sites hosted on the same backends and you want to control what to ban.
 
 ### Tuning
 

--- a/src/drivers/Varnish.php
+++ b/src/drivers/Varnish.php
@@ -76,6 +76,7 @@ class Varnish extends AbstractPurger implements CachePurgeInterface
      */
     public function purgeAll()
     {
+        $this->headers['Varnish_Ban_Key'] = getenv('VARNISH_BAN_KEY');
         return $this->sendPurgeRequest([
             'headers'  => $this->headers
         ], 'BAN');


### PR DESCRIPTION
VARNISH_BAN_KEY lets you specify a unique id which you can pick up in your VCL and issue the correct bans. Very useful when you have multiple sites hosted on the same backends and you want to control what to ban.