### PR TITLE
Trigger purge before/after events

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -19,6 +19,7 @@ class Plugin extends BasePlugin
 {
     // Event names
     const EVENT_AFTER_SET_TAG_HEADER = 'upper_after_set_tag_header';
+    const EVENT_BEFORE_PURGE = 'upper_before_purge';
     const EVENT_AFTER_PURGE = 'upper_after_purge';
 
     // Tag prefixes

--- a/src/events/PurgeEvent.php
+++ b/src/events/PurgeEvent.php
@@ -13,8 +13,8 @@ class PurgeEvent extends Event
     // =========================================================================
 
     /**
-     * @var array Array of tags
-     */
-    public $tags = [];
+    * @var string tag
+    */
+    public $tag;
 
 }


### PR DESCRIPTION
Since it was unused, I change PurgeEvent to fire for each tag, instead of the tags array.

I added a `EVENT_BEFORE_PURGE` for devs could manipulate and/or filter out tags, and EVENT_BEFORE_AFTER for anything else.