### PR TITLE
Update Cloudflare driver to implement scoped API tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,7 @@ KEYCDN_ZONE_ID=<REPLACE-ME>
 
 ```
 UPPER_DRIVER=cloudflare
-CLOUDFLARE_API_KEY=<REPLACE-ME>
-CLOUDFLARE_API_EMAIL=<REPLACE-ME>
+CLOUDFLARE_API_TOKEN=<REPLACE-ME>
 CLOUDFLARE_ZONE_ID=<REPLACE-ME>
 CLOUDFLARE_DOMAIN=https://<REPLACE-ME>
 ```
@@ -70,6 +69,8 @@ CLOUDFLARE_DOMAIN=https://<REPLACE-ME>
 By default, Cloudflare's CDN  does not cache HTML content. You need to create a [**Cache Level: Cache Everything**](https://support.cloudflare.com/hc/en-us/articles/202775670-How-Do-I-Tell-Cloudflare-What-to-Cache-) Page Rule to enable caching for "pages".
 
 If you don't use Cloudflare Enterprise with native `Cache-Tag` support, make sure to enable `useLocalTags` in your `config/upper.php` file (default), otherwise disable it.
+
+You can generate a token in the Cloudflare dashboard. You want to create a custom token with the "Zone.Cache Purge" permission that is restricted to the DNS zone(s) you wish to clear Cloudflare's cache for.
 
  
 ### Varnish Setup

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -61,7 +61,6 @@ class Plugin extends BasePlugin
             'tagCollection' => TagCollection::class
         ]);
 
-
         // Attach Behaviors
         \Craft::$app->getResponse()->attachBehavior('cache-control', CacheControlBehavior::class);
         \Craft::$app->getResponse()->attachBehavior('tag-header', TagHeaderBehavior::class);

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -61,6 +61,11 @@ class Plugin extends BasePlugin
             'tagCollection' => TagCollection::class
         ]);
 
+
+        // Attach Behaviors
+        \Craft::$app->getResponse()->attachBehavior('cache-control', CacheControlBehavior::class);
+        \Craft::$app->getResponse()->attachBehavior('tag-header', TagHeaderBehavior::class);
+
         // Register event handlers
         EventRegistrar::registerFrontendEvents();
         EventRegistrar::registerCpEvents();
@@ -69,11 +74,6 @@ class Plugin extends BasePlugin
         if ($this->getSettings()->useLocalTags) {
             EventRegistrar::registerFallback();
         }
-
-        // Attach Behaviors
-        \Craft::$app->getResponse()->attachBehavior('cache-control', CacheControlBehavior::class);
-        \Craft::$app->getResponse()->attachBehavior('tag-header', TagHeaderBehavior::class);
-
     }
 
     // ServiceLocators

--- a/src/config.example.php
+++ b/src/config.example.php
@@ -53,12 +53,12 @@ return [
         'cloudflare' => [
             'tagHeaderName'      => 'Cache-Tag',
             'tagHeaderDelimiter' => ',',
-            'apiToken'           => getenv('CLOUDFLARE_API_EMAIL'),
+            'apiToken'           => getenv('CLOUDFLARE_API_TOKEN'),
             'zoneId'             => getenv('CLOUDFLARE_ZONE_ID'),
             'domain'             => getenv('CLOUDFLARE_DOMAIN'),
             // deprecated, do not use for new installs
-            //'apiKey'             => getenv('CLOUDFLARE_API_KEY'),
-            //'apiEmail'           => getenv('CLOUDFLARE_API_EMAIL'),
+            'apiKey'             => getenv('CLOUDFLARE_API_KEY'),
+            'apiEmail'           => getenv('CLOUDFLARE_API_EMAIL'),
         ],
 
         // Dummy driver (default)

--- a/src/config.example.php
+++ b/src/config.example.php
@@ -53,10 +53,12 @@ return [
         'cloudflare' => [
             'tagHeaderName'      => 'Cache-Tag',
             'tagHeaderDelimiter' => ',',
-            'apiKey'             => getenv('CLOUDFLARE_API_KEY'),
-            'apiEmail'           => getenv('CLOUDFLARE_API_EMAIL'),
+            'apiToken'           => getenv('CLOUDFLARE_API_EMAIL'),
             'zoneId'             => getenv('CLOUDFLARE_ZONE_ID'),
-            'domain'             => getenv('CLOUDFLARE_DOMAIN')
+            'domain'             => getenv('CLOUDFLARE_DOMAIN'),
+            // deprecated, do not use for new installs
+            //'apiKey'             => getenv('CLOUDFLARE_API_KEY'),
+            //'apiEmail'           => getenv('CLOUDFLARE_API_EMAIL'),
         ],
 
         // Dummy driver (default)


### PR DESCRIPTION
Implements #38. Legacy/global API keys still work but logs a Craft deprecation warning.

I also found I had to make one change outside of the CF driver (e96c7e4) in order to get the unreleased / 1.6.x changes to run, as (for me anyway) `EventRegistrar::registerFrontendEvents()` expected `Response` to already have the plugins custom behaviours attached to it