### PR TITLE
Fix template usage

### DIFF
--- a/src/CacheResponse.php
+++ b/src/CacheResponse.php
@@ -1,11 +1,11 @@
 <?php namespace ostark\upper;
 
-use craft\web\Response;
+use yii\base\Response;
 
 class CacheResponse
 {
     /**
-     * @var \craft\web\Response|\ostark\upper\behaviors\CacheControlBehavior
+     * @var \yii\base\Response|\ostark\upper\behaviors\CacheControlBehavior
      */
     public $response;
 
@@ -16,14 +16,26 @@ class CacheResponse
 
     public function never()
     {
+        if (!$this->isWebResponse()) {
+            return;
+        }
+
         $this->response->addCacheControlDirective('private');
         $this->response->addCacheControlDirective('no-cache');
     }
 
     public function for(string $time)
     {
+        if (!$this->isWebResponse()) {
+            return;
+        }
+
         $seconds = strtotime($time) - time();
         $this->response->setSharedMaxAge($seconds);
     }
 
+    public function isWebResponse()
+    {
+        return $this->response instanceof \craft\web\Response;
+    }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -61,9 +61,6 @@ class Plugin extends BasePlugin
             'tagCollection' => TagCollection::class
         ]);
 
-        // Register Twig extension
-        \Craft::$app->getView()->registerTwigExtension(new TwigExtension);
-
         // Attach Behaviors
         \Craft::$app->getResponse()->attachBehavior('cache-control', CacheControlBehavior::class);
         \Craft::$app->getResponse()->attachBehavior('tag-header', TagHeaderBehavior::class);
@@ -78,7 +75,7 @@ class Plugin extends BasePlugin
         }
 
         // Register Twig extension
-        \Craft::$app->getView()->registerTwigExtension(new TwigExtension());
+        \Craft::$app->getView()->registerTwigExtension(new TwigExtension);
     }
 
     // ServiceLocators

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -62,7 +62,7 @@ class Plugin extends BasePlugin
         ]);
 
         // Register Twig extension
-        Craft::$app->getView()->registerTwigExtension(new TwigExtension);
+        \Craft::$app->getView()->registerTwigExtension(new TwigExtension);
 
         // Attach Behaviors
         \Craft::$app->getResponse()->attachBehavior('cache-control', CacheControlBehavior::class);

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -61,6 +61,9 @@ class Plugin extends BasePlugin
             'tagCollection' => TagCollection::class
         ]);
 
+        // Register Twig extension
+        Craft::$app->getView()->registerTwigExtension(new TwigExtension);
+
         // Attach Behaviors
         \Craft::$app->getResponse()->attachBehavior('cache-control', CacheControlBehavior::class);
         \Craft::$app->getResponse()->attachBehavior('tag-header', TagHeaderBehavior::class);
@@ -73,6 +76,9 @@ class Plugin extends BasePlugin
         if ($this->getSettings()->useLocalTags) {
             EventRegistrar::registerFallback();
         }
+
+        // Register Twig extension
+        \Craft::$app->getView()->registerTwigExtension(new TwigExtension());
     }
 
     // ServiceLocators

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -15,7 +15,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
     {
         return [
             'upper' => [
-                'cache' => \Craft::createObject(CacheResponse::class)
+                'cache' => new CacheResponse(\Craft::$app->getResponse())
             ]
         ];
     }


### PR DESCRIPTION
Looks like this feature came in a little half-baked…

The TwigExtension was there but never registered.
Also, type checking on the constructor would fail on console requests.