### PR TITLE
adds uid_urlhash_idx on installation to support

### DIFF
--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -53,6 +53,7 @@ class Install extends Migration
 
             echo "  > Create index: urlhash_idx" . PHP_EOL;
             $this->createIndex('urlhash_idx', Plugin::CACHE_TABLE, 'urlHash', true);
+            $this->createIndex('uid_urlhash_ids', Plugin::CACHE_TABLE, 'uid,urlHash', true);
 
             $this->execute("CREATE INDEX tags_array ON " . Plugin::CACHE_TABLE . " USING GIN(tags)");
 


### PR DESCRIPTION
without this Postgres will complain that "ERROR:  there is no unique or exclusion constraint matching the ON CONFLICT specification" with the following SQL,

INSERT INTO "upper_cache" ("urlHash", "url", "tags", "headers", "siteId", "dateCreated", "dateUpdated", "uid") VALUES ($1, $2, ARRAY[]::varchar[], $3, $4, $5, $6, $7) ON CONFLICT ("uid", "urlHash") DO UPDATE SET "urlHash"=$8, "url"=$9, "tags"=ARRAY[]::varchar[], "headers"=$10, "siteId"=$11, "dateCreated"=$12, "dateUpdated"=$13, "uid"=$14

Probably would need an additional migration for existing installations. If this makes sense I can make that migration before this merges.