### PR TITLE
Adding optional limit to header size

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -39,6 +39,7 @@ class Plugin extends BasePlugin
 
     // Header
     const INFO_HEADER_NAME = 'X-UPPER-CACHE';
+    const TRUNCATED_HEADER_NAME = 'X-UPPER-CACHE-TRUNCATED';
 
     public $schemaVersion = '1.0.1';
 

--- a/src/TagCollection.php
+++ b/src/TagCollection.php
@@ -21,6 +21,28 @@ class TagCollection
         return $this->tags;
     }
 
+    public function getUntilMaxBytes($maxBytes=null)
+    {
+        if ($maxBytes === null) {
+            return $this->tags;
+        }
+
+        $tags = [];
+        $runningSize = 0;
+        foreach ($this->tags as $tag) {
+            $thisSize = mb_strlen($tag.' ', '8bit');
+
+            if ($runningSize + $thisSize > $maxBytes) {
+                break;
+            }
+
+            $runningSize += $thisSize;
+            $tags[] = $tag;
+        }
+
+        return $tags;
+    }
+
     public function addTagsFromElement(array $elementRawQueryResult = null)
     {
         if (!is_array($elementRawQueryResult)) {

--- a/src/TagCollection.php
+++ b/src/TagCollection.php
@@ -21,7 +21,7 @@ class TagCollection
         return $this->tags;
     }
 
-    public function getUntilMaxBytes($maxBytes=null)
+    public function getUntilMaxBytes(int $maxBytes = null)
     {
         if ($maxBytes === null) {
             return $this->tags;

--- a/src/config.example.php
+++ b/src/config.example.php
@@ -22,6 +22,13 @@ return [
     // 1-8 characters, special chars get removed
     'keyPrefix'     => getenv('UPPER_KEY_PREFIX') ?: '',
 
+    // Optional maximum length for the cache tag header. Setting this higher will
+    // allow Upper to return more tags in the header. However, it will also require
+    // more resources on the server to store/buffer the tags. Ensure you have enough
+    // room in any proxy/CDN to display large headers if you raise this above 4k.
+    // Stored in bytes, typically as `16 * 1024` for 16KB
+    'maxBytesForCacheTagHeader' => null,
+
     // Drivers settings
     'drivers'       => [
 

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -57,6 +57,13 @@ class Settings extends Model
      */
     public $keyPrefix = '';
 
+    /**
+     * Max kilobytes of the X-Cachetag header
+     *
+     * @var string
+     */
+    public $maxBytesForCacheTagHeader = null;
+
     // Public Methods
     // =========================================================================
 

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -60,7 +60,7 @@ class Settings extends Model
     /**
      * Max kilobytes of the X-Cachetag header
      *
-     * @var string
+     * @var int
      */
     public $maxBytesForCacheTagHeader = null;
 


### PR DESCRIPTION
Addresses some issues identified in https://github.com/ostark/upper/issues/33.

I've set my nginx header buffer sufficiently large. However, I still have some complex pages that just load _a lot_ of nested elements. On those pages it would be nice if the header didn't grow forever because try as I might, eventually, I'll run out of buffer space.

This takes a slightly different approach than discussed in the linked issue because I find the full tag listing in the database _very_ helpful and the only thing I _really_ wanted to limit was the header. So, this truncates the header if it's larger than max bytes while leaving the logging and everything else to interact with the full tag listing. When header truncation does occur it adds in an additional header that will tell the user how many tags were truncated.